### PR TITLE
Add minimal macOS desktop counter menu bar app

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>DesktopCount</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.desktopcount</string>
+    <key>CFBundleName</key>
+    <string>DesktopCount</string>
+    <key>LSUIElement</key>
+    <string>1</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# DesktopCount
+
+DesktopCount is a minimal menu bar application that displays the number of the current macOS desktop (Space). The icon updates automatically whenever you switch spaces.
+
+## Installation
+
+```bash
+git clone <repo-url>
+cd DesktopCount
+./install.sh
+```
+
+The script builds the app with `swiftc` (requires the Xcode command line tools) and installs it to `/Applications/DesktopCount.app`.
+
+## Usage
+
+After installation the app launches automatically. The menu bar will show a number representing your active desktop. Switch spaces as usual and the number updates immediately.
+
+No additional UI is provided – simply quit the app from the menu bar if needed.

--- a/Sources/DesktopCount.swift
+++ b/Sources/DesktopCount.swift
@@ -1,0 +1,60 @@
+import Cocoa
+
+// Private CoreGraphics functions to inspect Spaces
+private typealias CGSConnection = UInt32
+
+@_silgen_name("_CGSDefaultConnection")
+fileprivate func _CGSDefaultConnection() -> CGSConnection
+
+@_silgen_name("CGSCopyManagedDisplaySpaces")
+fileprivate func CGSCopyManagedDisplaySpaces(_ conn: CGSConnection) -> CFArray
+
+@_silgen_name("CGSCopyActiveMenuBarSpace")
+fileprivate func CGSCopyActiveMenuBarSpace(_ conn: CGSConnection) -> UInt64
+
+/// Determine the index of the currently active Space (1-based).
+fileprivate func currentSpaceIndex() -> Int {
+    let conn = _CGSDefaultConnection()
+    guard let displays = CGSCopyManagedDisplaySpaces(conn) as? [[String: Any]] else {
+        return 0
+    }
+    let activeSpace = CGSCopyActiveMenuBarSpace(conn)
+    for display in displays {
+        if let spaces = display["Spaces"] as? [[String: Any]] {
+            for (idx, space) in spaces.enumerated() {
+                if let sid = space["id64"] as? UInt64, sid == activeSpace {
+                    return idx + 1
+                }
+            }
+        }
+    }
+    return 0
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    var statusItem: NSStatusItem!
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        update()
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(spaceChanged),
+            name: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil)
+    }
+
+    @objc func spaceChanged(_ note: Notification) {
+        update()
+    }
+
+    private func update() {
+        statusItem.button?.title = "\(currentSpaceIndex())"
+    }
+}
+
+let app = NSApplication.shared
+let delegate = AppDelegate()
+app.delegate = delegate
+app.run()

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+APP="DesktopCount"
+
+rm -rf "$APP.app"
+mkdir -p "$APP.app/Contents/MacOS"
+cp Info.plist "$APP.app/Contents/Info.plist"
+
+swiftc Sources/DesktopCount.swift -framework Cocoa -o "$APP.app/Contents/MacOS/$APP"
+
+cp -R "$APP.app" "/Applications/$APP.app"
+
+echo "Installed to /Applications/$APP.app"
+open "/Applications/$APP.app"


### PR DESCRIPTION
## Summary
- implement `DesktopCount` menu bar application in Swift
- include `Info.plist` so the app runs as a background menu bar agent
- add an install script to compile and copy the app to `/Applications`
- document installation and usage

## Testing
- `swiftc Sources/DesktopCount.swift -framework Cocoa -o DesktopCount` *(fails: no module 'Cocoa')*

------
https://chatgpt.com/codex/tasks/task_e_6849aa6c24b4832e85b1f746129df594