### PR TITLE
Include ApplicationServices in build

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,10 @@ rm -rf "$APP.app"
 mkdir -p "$APP.app/Contents/MacOS"
 cp Info.plist "$APP.app/Contents/Info.plist"
 
-swiftc Sources/DesktopCount.swift -framework Cocoa -o "$APP.app/Contents/MacOS/$APP"
+swiftc Sources/DesktopCount.swift \
+    -framework Cocoa \
+    -framework ApplicationServices \
+    -o "$APP.app/Contents/MacOS/$APP"
 
 cp -R "$APP.app" "/Applications/$APP.app"
 


### PR DESCRIPTION
## Summary
- include `ApplicationServices` when compiling the app

## Testing
- `./install.sh` *(fails: no such module `Cocoa`)*

------
https://chatgpt.com/codex/tasks/task_e_6849b0defc40832e8a535859d1f02d78