### PR TITLE
Improve installation docs and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DesktopCount
 
-DesktopCount is a minimal menu bar application that displays the number of the current macOS desktop (Space). The icon updates automatically whenever you switch spaces.
+DesktopCount is a tiny menu bar application for macOS that shows the index of the currently active desktop (Space).  It relies on the [yabai](https://github.com/koekeishiya/yabai) window manager to determine the focused space and updates automatically whenever you switch.
 
 ## Installation
 
@@ -10,10 +10,10 @@ cd DesktopCount
 ./install.sh
 ```
 
-The script builds the app with `swiftc` (requires the Xcode command line tools) and installs it to `/Applications/DesktopCount.app`.
+The script builds the Xcode project using `xcodebuild` and installs `DesktopCount.app` into `~/Applications` by default.  Set the `DEST_DIR` environment variable if you wish to install elsewhere.  Xcode command line tools must be installed.
 
 ## Usage
 
-After installation the app launches automatically. The menu bar will show a number representing your active desktop. Switch spaces as usual and the number updates immediately.
+After installation launch **DesktopCount.app** from Finder or Spotlight.  The menu bar icon displays the number of your active desktop and updates whenever you change spaces.
 
-No additional UI is provided – simply quit the app from the menu bar if needed.
+No additional interface is provided—quit the app from its menu bar icon if needed.

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,15 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 APP_NAME="DesktopCount"
-PROJECT_DIR="$(dirname "$0")/DesktopCount"
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)/DesktopCount"
 BUILD_DIR="$PROJECT_DIR/build"
-DEST_DIR="$HOME/Applications"
+DEST_DIR="${DEST_DIR:-$HOME/Applications}"
+
+if ! command -v xcodebuild >/dev/null; then
+  echo "xcodebuild not found. Please install Xcode command line tools." >&2
+  exit 1
+fi
 
 # Build the app
 xcodebuild -project "$PROJECT_DIR/$APP_NAME.xcodeproj" -scheme "$APP_NAME" -configuration Release -derivedDataPath "$BUILD_DIR" build


### PR DESCRIPTION
## Summary
- document dependency on yabai
- clarify installation location and command line usage
- update install.sh for robustness with xcodebuild detection

## Testing
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849b549140c832e8b8ded7b3135d43c